### PR TITLE
Changes for RightScale integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Usage
 
 To install just ImageMagick,
 
-  include_recipe "imagemagick"
+  include_recipe "imagemagick::default"
 
 In your own recipe/cookbook. To install the development libraries,
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "imagemagick"
 maintainer       "Opscode, Inc."
 maintainer_email "cookbooks@opscode.com"
 license          "Apache 2.0"

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ description      "Installs/Configures imagemagick"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.2.2"
 
-recipe "imagemagick", "Installs imagemagick package"
+recipe "imagemagick::default", "Installs imagemagick package"
 recipe "imagemagick::devel", "Installs imagemagick development libraries"
 recipe "imagemagick::rmagick", "Installs rmagick gem"
 


### PR DESCRIPTION
In it's current form, the missing "name" parameter in the metadata.rb causes RightScale to import the cookbook as undefined. The addition of the "name" in the parameters makes everything work as it should. Adding the ::default to the base recipe is just following the convention they use. 
